### PR TITLE
make demo vm configurable

### DIFF
--- a/demo/Vagrantfile
+++ b/demo/Vagrantfile
@@ -1,49 +1,79 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+# To customize: create xtlocal.rb in the current directory
+#               containing assignments to override these defaults
+# xtHostOffset is a convenience variable.
+#   $ egrep ^xtHost Vagrantfile > xtlocal.rb
+#   then edit xtHostOffset, xtHostAddr, xtHostName
+xtHostOffset    = 0
 
-Vagrant.require_version ">= 1.6.3"
+xtBox           = "ubuntu/trusty64"
+xtBoxUrl        = nil
+xtForwardX11    = true
+xtGuestAppPort  = 8443
+xtGuestRestPort = 3000
+xtGuestWebPort  = 8888
+xtGui           = false
+xtHostAddr      = "192.168.33.10"
+xtHostAppPort   = xtGuestAppPort  + xtHostOffset
+xtHostName      = "xtuple-server"
+xtHostRestPort  = xtGuestRestPort + xtHostOffset
+xtHostWebPort   = xtGuestWebPort  + xtHostOffset
+xtPostgresVer   = "9.3"
+xtSourceDir     = "../../dev"
+xtSourceMountPt = "/home/vagrant/dev"
+xtVagrantVer    = ">= 1.6.4"
+xtVboxGuestAU   = true
+xtVboxGuestNR   = true
+xtVboxMemory    = "4096"
+xtVmwareMemory  = "4096"
+
+if File.file? "xtlocal.rb"
+  IO.foreach("xtlocal.rb") { |line| eval line }
+end
+
+Vagrant.require_version xtVagrantVer
 
 Vagrant.configure("2") do |config|
-
-  # This is the VagrantFile for generating the xTuple Sales Demo box.
-
-  config.vm.hostname = "xtuple-server"
+  config.vm.hostname = xtHostName
 
   config.vm.post_up_message = "Welcome to the xTuple Server virtual environment.
   Use the command 'vagrant ssh' to access your server."
 
-  # Set default package name when exporting
-  config.package.name = "xtuple-mobile.box"
-
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = xtBox
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = xtBoxUrl
 
   # Here we're extending the boot to give Postgres time to load
   config.vm.boot_timeout = 10000
 
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # Control the permissions of this file by setting owner: "root",
-  # group: "root"
-  #config.vm.synced_folder "dev", "/home/vagrant/dev", create: true
+  # set auto_update to false, if you do NOT want to check the correct
+  # additions version when booting this machine
+  config.vbguest.auto_update = xtVboxGuestAU
+
+  # do NOT download the iso file from a webserver
+  config.vbguest.no_remote = xtVboxGuestNR
 
   # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network :forwarded_port, guest: 8888, host: 8888
-  config.vm.network :forwarded_port, guest: 8443, host: 8443
-  config.vm.network :forwarded_port, guest: 3000, host: 3000
+  # within the machine from a port on the host machine.
+  config.vm.network :forwarded_port, guest: xtGuestWebPort,  host: xtHostWebPort
+  config.vm.network :forwarded_port, guest: xtGuestAppPort,  host: xtHostAppPort
+  config.vm.network :forwarded_port, guest: xtGuestRestPort, host: xtHostRestPort
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network :private_network, ip: "192.168.33.10"
+  config.vm.network :private_network, ip: xtHostAddr
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
   # your network.
   # config.vm.network :public_network
+
+  # Share a folder with the guest VM: path-on-host path-on-guest [options]
+  config.vm.synced_folder xtSourceDir, xtSourceMountPt, create: true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -52,15 +82,24 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
     # Use VBoxManage to customize the VM
-    # This line increases memory
-    v.customize ["modifyvm", :id, "--memory", "2048"]
+    # This line disable hw virtualization and increases memory
+    v.customize ["modifyvm", :id, "--memory", xtVboxMemory]
 
-    # Boot the VM in Gui mode
-    #v.gui = true
+    # Via http://blog.liip.ch/archive/2012/07/25/vagrant-and-node-js-quick-tip.html
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
+
+    # Debug VM by booting in Gui mode
+    v.gui = xtGui
+  end
+
+  config.vm.provider "vmware_fusion" do |v|
+    v.vmx["memsize"] = xtVmwareMemory
   end
 
   # This ensures that the locale is correctly set for Postgres
-  config.vm.provision "shell", inline: 'update-locale LC_ALL="en_US.UTF-8"'
+  config.vm.provision "shell", inline: 'update-locale LC_ALL="en_US.utf8"'
 
   config.ssh.forward_agent = true
+  config.ssh.forward_x11 = xtForwardX11
+
 end

--- a/xtlocal.rb.sample
+++ b/xtlocal.rb.sample
@@ -1,8 +1,8 @@
 xtHostOffset    = 1
 xtHostAddr      = "192.168.33.11"
-xtHostAppPort   = xtGuestAppPort  + xtPortOffset
+xtHostAppPort   = xtGuestAppPort  + xtHostOffset
 xtHostName      = "second-vm"
-xtHostRestPort  = xtGuestRestPort + xtPortOffset
-xtHostWebPort   = xtGuestWebPort  + xtPortOffset
+xtHostRestPort  = xtGuestRestPort + xtHostOffset
+xtHostWebPort   = xtGuestWebPort  + xtHostOffset
 
 xtVboxMemory    = "2048"


### PR DESCRIPTION
This brings one more Vagrantfile into the configurable fold. The eventual goal is to have one Vagrantfile with multiple provisioners, each provisioner supplying the bits for a specific vagrant vm usage (e.g. different provisioners for demo and bi, and a bi demo could be configured by running both).