### PR TITLE
Fix: install plv8 v2.0

### DIFF
--- a/webdev_setup.sh
+++ b/webdev_setup.sh
@@ -18,5 +18,16 @@ bash scripts/install_xtuple.sh -d $PGVER -q $QTVER      || die
 echo "Adding Vagrant PostgreSQL Access Rule"
 echo "host all all  0.0.0.0/0 trust" | sudo tee -a /etc/postgresql/${PGVER}/main/pg_hba.conf
 
+# Install plv8 v2.0+ required for xTupleCommerce extension
+sudo apt-get -q -y install libc++1 && \
+cd ${HOME} && \
+wget http://updates.xtuple.com/updates/plv8/linux64/xtuple_plv8.tgz && \
+tar xf xtuple_plv8.tgz && \
+cd xtuple_plv8 && \
+printf "\n" | sudo ./install_plv8.sh /usr && \
+cd ${HOME} && \
+rm -rf xtuple_plv8 && \
+rm xtuple_plv8.tgz
+
 echo "Restarting Postgres Database"
 sudo service postgresql restart


### PR DESCRIPTION
Using instructions from https://github.com/xtuple/xtuple/wiki/Installing-PLv8#linux-servers and @bendiy comment that `libc++1` is required.